### PR TITLE
Allow condition statement to not require brace when they are single-line

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ module.exports = {
     "ordered-imports": [false],
     "no-submodule-imports": [true, "lodash"],
     "quotemark": [true, "single", "jsx-double"],
-    "prettier": [true, { "print-width": 130 }]
+    "prettier": [true, { "print-width": 130 }],
+    "curly": ["error", "multi"]
   },
 };

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ module.exports = {
     "object-literal-sort-keys": false,
     "ordered-imports": [false],
     "no-submodule-imports": [true, "lodash"],
-    "quotemark": [true, "single", "jsx-double"]
+    "quotemark": [true, "single", "jsx-double"],
+    "prettier": [true, { "print-width": 130 }]
   },
 };


### PR DESCRIPTION
Will allow:

````ts
validateConfiguration(config: Configuration): void {
    if(!config) throw new Error('configuration object is required')
    if(!config.required) throw new Error('required property is required')
    if(!config.required) throw new Error('required property is required')
}
````


insteadof:

````ts
validateConfiguration(config: Configuration): void {
    if(!config) {
        throw new Error('configuration object is required')
    }
    if(!config.required) {
        throw new Error('required property is required')
    }
    if(!config.required) {
        throw new Error('required property is required')
    }
}
````